### PR TITLE
Configure karma tests for es6

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -5,15 +5,15 @@ angular.module('covey', [
 .config(($routeProvider) => {
   $routeProvider
     .when('/', {
-      templateURL: 'views/index.html',
+      templateUrl: 'views/index.html',
       controller: 'loginController',
     })
     .when('/coveys', {
-      templateURL: 'views/coveys.html',
+      templateUrl: 'views/coveys.html',
       controller: 'coveysController',
     })
     .when('/covey', {
-      templateURL: 'views/covey.html',
+      templateUrl: 'views/covey.html',
       controller: 'coveysController',
     });
 })

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,18 @@ module.exports = function (config) {
       'specs/client/clientExampleSpec.js',
     ],
 
+    preprocessors: {
+      'client/app.js': ['babel'],
+      'client/scripts/**/*.js': ['babel'],
+      'specs/**/*.js': ['babel'],
+    },
+
+    babelPreprocessor: {
+      options: {
+        presets: ['es2015']
+      }
+    },
+
     reporters: ['spec'],
 
     browsers: ['PhantomJS'],

--- a/specs/.eslintrc.json
+++ b/specs/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../.eslintrc.json",
+
+  "globals": {
+   "it": true,
+   "describe": true,
+   "before": true,
+   "beforeEach": true,
+   "inject": true,
+   "expect": true
+  }
+} 

--- a/specs/client/clientExampleSpec.js
+++ b/specs/client/clientExampleSpec.js
@@ -1,9 +1,20 @@
-'use strict';
-
-describe('Running', function () {
-
-  it('Should be running a test', function () {
-    expect([1,2,3][1]).to.equal(2);
+describe('Running', () => {
+  it('Should be running a test', () => {
+    expect([1, 2, 3][1]).to.equal(2);
   });
+});
 
+describe('Routing', () => {
+  let $route;
+  beforeEach(module('covey'));
+
+  beforeEach(inject(($injector) => {
+    $route = $injector.get('$route');
+  }));
+
+  it('Should have /coveys route, template, and controller', () => {
+    expect($route.routes['/coveys']).to.be.defined;
+    expect($route.routes['/coveys'].controller).to.equal('coveysController');
+    expect($route.routes['/coveys'].templateUrl).to.equal('views/coveys.html');
+  });
 });


### PR DESCRIPTION
Working in Issue #36 
Bug Fixes:
- eslint file added to specs to ignore mocha syntax
- changed angular routes to use "templateUrl"
- added example angular test